### PR TITLE
Take normal size image for XML feed

### DIFF
--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -312,7 +312,7 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$images[] = wp_get_attachment_image_src( $attachment_id, 'full' )[0];
+				$images[] = wp_get_attachment_image_src( $attachment_id, 'woocommerce_single' )[0];
 			}
 		}
 

--- a/src/ProductsXmlFeed.php
+++ b/src/ProductsXmlFeed.php
@@ -312,7 +312,7 @@ class ProductsXmlFeed {
 
 		if ( $attachment_ids && $product->get_image_id() ) {
 			foreach ( $attachment_ids as $attachment_id ) {
-				$images[] = wp_get_attachment_image_src( $attachment_id )[0];
+				$images[] = wp_get_attachment_image_src( $attachment_id, 'full' )[0];
 			}
 		}
 


### PR DESCRIPTION
This PR aims to solve [this issue](https://github.com/woocommerce/pinterest-for-woocommerce/issues/248)

### Changes proposed in this Pull Request:
The images loaded in `g:additional_image_link` field are full size and not thumbnails

### Screenshots:

### Detailed test instructions:
Verify that field g:additional_image_link is getting the full size images.

### Additional notes:

### Changelog entry