### PR TITLE
Show expected message on merchant declined status

### DIFF
--- a/assets/source/setup-guide/app/components/HealthCheck/index.js
+++ b/assets/source/setup-guide/app/components/HealthCheck/index.js
@@ -226,7 +226,7 @@ const HealthCheck = () => {
 
 	const notice = notices[ healthStatus.status ] || notices.error;
 
-	if ( notice.status === 'error' ) {
+	if ( notice.status === 'error' && ! notice.message ) {
 		notice.message =
 			healthStatus.message ||
 			__(


### PR DESCRIPTION

### Changes proposed in this Pull Request:

This PR aims to solve [this issue](https://github.com/woocommerce/pinterest-for-woocommerce/issues/230)

#

Fixed the expected error message for merchants with declined status:
From: "Could not fetch account status" to "Your merchant account is disapproved."


### Screenshots:

![image](https://user-images.githubusercontent.com/40774170/142287547-c6df0224-0ca9-4f66-9ce8-5674425e0077.png)


### Detailed test instructions:

1.  Get a declined Business account
2. Verify Notice message in Catalog tab


### Changelog entry

>
