### PR TITLE
Bugfix/do-not-syn-out-of-stock-hidden-products

### DIFF
--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -602,14 +602,19 @@ class ProductSync {
 			)
 		);
 
-		$product_ids = wc_get_products(
-			array(
-				'limit'  => -1,
-				'return' => 'ids',
-				'status' => 'publish',
-				'type'   => array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types ),
-			)
+		$products_query_args = array(
+			'limit'        => -1,
+			'return'       => 'ids',
+			'status'       => 'publish',
+			'type'         => array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types ),
 		);
+
+		// Do not sync out of stock products if woocommerce_hide_out_of_stock_items is set
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items') ) {
+			$products_query_args['stock_status'] = 'instock';
+		}
+
+		$product_ids = wc_get_products( $products_query_args );
 
 		if ( empty( $product_ids ) ) {
 			return array();

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -620,6 +620,20 @@ class ProductSync {
 			return array();
 		}
 
+		// Do not sync products with hidden visibility
+		$visible_product_ids = array();
+		foreach ( $product_ids as $index => $product_id ) {
+			$product = wc_get_product( $product_id );
+			if ( 'hidden' !== $product->get_catalog_visibility() ) {
+				$visible_product_ids[] = $product_id;
+			}
+		}
+		$product_ids = $visible_product_ids;
+
+		if ( empty( $product_ids ) ) {
+			return array();
+		}
+
 		$products_count = count( $product_ids );
 
 		// Get Variations of the current product and inject them into our array.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Changes on this PR aims to solve [this issue](https://github.com/woocommerce/pinterest-for-woocommerce/issues/206)

#

- The products with Hidden visibility won't be synced to the feed
- If the option woocommerce_hide_out_of_stock_items is set, the products out of stock won't be synced to the feed


### Screenshots:


### Detailed test instructions:

1.  Set out of stock for 1 or many products
2.  Set the option woocommerce_hide_out_of_stock_items and set the catalog visibility for 1 or many products as Hidden
3. Regenerate the feed file
4. The products that are out of stock or hidden must not appear in the feed file

### Changelog entry

>
