### PR TITLE
Remove unnecesary fields on create merchant method

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -401,38 +401,15 @@ class Base {
 	/**
 	 * Creates a merchant for the authenticated user or returns the existing one.
 	 *
-	 * @param array $args The arguments to be passed to the API request.
-	 *
 	 * @return mixed
 	 */
-	public static function maybe_create_merchant( $args = array() ) {
+	public static function maybe_create_merchant() {
 
 		$merchant_name = apply_filters( 'pinterest_for_woocommerce_default_merchant_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
 
-		$args_to_remove = apply_filters(
-			'pinterest_for_woocommerce_create_merchant_args',
-			array(
-				'feed_location',
-				'feed_format',
-				'feed_default_currency',
-				'default_availability_type',
-				'country',
-				'locale',
-			)
-		);
-
-		foreach ( $args_to_remove as $arg_key ) {
-			if ( isset( $args[ $arg_key ] ) || null === $args[ $arg_key ] ) {
-				unset( $args[ $arg_key ] );
-			}
-		}
-
-		$args = wp_parse_args(
-			$args,
-			array(
-				'display_name'                      => $merchant_name,
-				'return_merchant_if_already_exists' => true,
-			)
+		$args = array(
+			'display_name'                      => $merchant_name,
+			'return_merchant_if_already_exists' => true,
 		);
 
 		return self::make_request(

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -409,6 +409,24 @@ class Base {
 
 		$merchant_name = apply_filters( 'pinterest_for_woocommerce_default_merchant_name', esc_html__( 'Auto-created by Pinterest for WooCommerce', 'pinterest-for-woocommerce' ) );
 
+		$args_to_remove = apply_filters(
+			'pinterest_for_woocommerce_create_merchant_args',
+			array(
+				'feed_location',
+				'feed_format',
+				'feed_default_currency',
+				'default_availability_type',
+				'country',
+				'locale',
+			)
+		);
+
+		foreach ( $args_to_remove as $arg_key ) {
+			if ( isset( $args[ $arg_key ] ) || null === $args[ $arg_key ] ) {
+				unset( $args[ $arg_key ] );
+			}
+		}
+
 		$args = wp_parse_args(
 			$args,
 			array(

--- a/src/Merchants.php
+++ b/src/Merchants.php
@@ -23,14 +23,12 @@ class Merchants {
 	 * returned by the Advertisers endpoint, it will be used, otherwise an
 	 * attempt to create a new one is made.
 	 *
-	 * @param array $feed_args The arguments used to create the feed.
-	 *
 	 * @return array
 	 *
 	 * @throws \Throwable PHP Exception.
 	 * @throws \Exception PHP Exception.
 	 */
-	public static function get_merchant( $feed_args = array() ) {
+	public static function get_merchant() {
 
 		$merchant          = false;
 		$merchant_id       = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
@@ -65,7 +63,7 @@ class Merchants {
 
 		if ( ! $merchant || ( 'success' !== $merchant['status'] && 650 === $merchant['code'] ) ) {  // https://developers.pinterest.com/docs/redoc/#tag/API-Response-Codes Merchant not found 650.
 			// Try creating one.
-			$merchant = API\Base::maybe_create_merchant( $feed_args );
+			$merchant = API\Base::maybe_create_merchant();
 			if ( 'success' === $merchant['status'] ) {
 				Pinterest_For_Woocommerce()::save_data( 'merchant_id', $merchant['data']->id );
 			}

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -542,7 +542,7 @@ class ProductSync {
 	private static function register_feed( $feed_args ) {
 
 		// Get merchant object.
-		$merchant   = Merchants::get_merchant( $feed_args );
+		$merchant   = Merchants::get_merchant();
 		$registered = false;
 
 		if ( ! empty( $merchant['data']->id ) && 'declined' === $merchant['data']->product_pin_approval_status ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Aimed to solve [this issue](https://github.com/woocommerce/pinterest-for-woocommerce/issues/196).
There were some unused parameters being sent on the create merchant request.

### Screenshots:

### Detailed test instructions:

1. Create a new WP instance and connect a Pinterest account
2. Verify the request to create the merchant in the Log, it should be similar to:
`DEBUG POST Request: https://api.pinterest.com/v3/commerce/product_pin_merchants/?display_name=Auto Created by Pinterest For WooCommerce&return_merchant_if_already_exists=1`

### Changelog entry
>
