### PR TITLE
Bugfix/do not sync out of stock hidden products

### DIFF
--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -629,14 +629,12 @@ class ProductSync {
 			)
 		);
 
-		$product_ids = wc_get_products(
-			array(
-				'limit'      => -1,
-				'return'     => 'ids',
-				'status'     => 'publish',
-				'visibility' => 'catalog',
-				'type'       => array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types ),
-			)
+		$products_query_args = array(
+			'limit'      => -1,
+			'return'     => 'ids',
+			'status'     => 'publish',
+			'visibility' => 'catalog',
+			'type'       => array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types ),
 		);
 
 		// Do not sync out of stock products if woocommerce_hide_out_of_stock_items is set.

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -621,10 +621,11 @@ class ProductSync {
 
 		$product_ids = wc_get_products(
 			array(
-				'limit'  => -1,
-				'return' => 'ids',
-				'status' => 'publish',
-				'type'   => array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types ),
+				'limit'      => -1,
+				'return'     => 'ids',
+				'status'     => 'publish',
+				'visibility' => 'catalog',
+				'type'       => array_diff( array_merge( array_keys( wc_get_product_types() ) ), $excluded_product_types ),
 			)
 		);
 

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -118,7 +118,12 @@ class ProductSync {
 			/**
 			 * Mark feed as needing re-generation on changes to the woocommerce_hide_out_of_stock_items setting
 			 */
-			add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_hide_out_of_stock_items', array( __CLASS__, 'mark_feed_dirty_on_woocommerce_setting_change' ), 10, 2 );
+			add_action(
+				'update_option_woocommerce_hide_out_of_stock_items',
+				function () {
+					Pinterest_For_Woocommerce()::save_data( 'feed_dirty', true );
+				}
+			);
 
 			// If feed is dirty on completion of feed generation, reschedule it.
 			add_action( 'pinterest_for_woocommerce_feed_generated', array( __CLASS__, 'reschedule_if_dirty' ) );
@@ -682,31 +687,6 @@ class ProductSync {
 		}
 
 		Pinterest_For_Woocommerce()::save_data( 'feed_dirty', true );
-	}
-
-	/**
-	 * Mark feed as dirty if the woocommerce setting changed the value
-	 *
-	 * @param mixed $value  The new value of the woocommerce setting.
-	 * @param array $option The option details.
-	 *
-	 * @return mixed $value
-	 */
-	public static function mark_feed_dirty_on_woocommerce_setting_change( $value, $option ) {
-		if ( strstr( $option['id'], '[' ) ) {
-			parse_str( $option['id'], $option_name_array );
-			$option_name = current( array_keys( $option_name_array ) );
-		} else {
-			$option_name = $option['id'];
-		}
-
-		$old_value = get_option( $option_name );
-
-		if ( $old_value !== $value ) {
-			Pinterest_For_Woocommerce()::save_data( 'feed_dirty', true );
-		}
-
-		return $value;
 	}
 
 

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -628,6 +628,13 @@ class ProductSync {
 			)
 		);
 
+		// Do not sync out of stock products if woocommerce_hide_out_of_stock_items is set.
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
+			$products_query_args['stock_status'] = 'instock';
+		}
+
+		$product_ids = wc_get_products( $products_query_args );
+
 		if ( empty( $product_ids ) ) {
 			return array();
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Changes on this PR aims to solve [this issue](https://github.com/woocommerce/pinterest-for-woocommerce/issues/206)

#

- The products with visibility set to 'hidden' won't be synced to the feed
- If the option `woocommerce_hide_out_of_stock_items` is set, the products out of stock won't be synced to the feed


### Screenshots:


### Detailed test instructions:

1.  Set out of stock for 1 or many products
2.  Set the option woocommerce_hide_out_of_stock_items and set the catalog visibility for 1 or many products as Hidden
3. Regenerate the feed file
4. The products that are out of stock or hidden must not appear in the feed file

### Changelog entry

>
