### PR TITLE
Fix/228 wrong feed registration status multiple feed profiles

### DIFF
--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -460,7 +460,43 @@ class Base {
 
 
 	/**
-	 * Get a specific merchant's feeds using the given arguments.
+	 * Get a specific merchant feed using the given arguments.
+	 *
+	 * @param string $merchant_id The merchant ID the feed belongs to.
+	 * @param string $feed_id     The ID of the feed.
+	 *
+	 * @return mixed|null
+	 */
+	public static function get_merchant_feed( $merchant_id, $feed_id ) {
+		$feeds = self::get_merchant_feeds( $merchant_id );
+
+		if ( 'success' !== $feeds['status'] ) {
+			return null;
+		}
+
+		$feed_object = null;
+
+		if ( is_array( $feeds['data'] ) ) {
+
+			foreach ( $feeds['data'] as $feed_profile ) {
+
+				if ( $feed_id === $feed_profile->id ) {
+					$feed_object = $feed_profile;
+				}
+			}
+		} else {
+
+			if ( $feed_id === $feeds['data'] ) {
+				$feed_object = $feeds['data'];
+			}
+		}
+
+		return $feed_object;
+	}
+
+
+	/**
+	 * Get a merchant's feeds.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.
 	 *

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -468,30 +468,38 @@ class Base {
 	 * @return mixed|null
 	 */
 	public static function get_merchant_feed( $merchant_id, $feed_id ) {
-		$feeds = self::get_merchant_feeds( $merchant_id );
+		try {
 
-		if ( 'success' !== $feeds['status'] ) {
-			return null;
-		}
+			$feeds = self::get_merchant_feeds( $merchant_id );
 
-		$feed_object = null;
+			if ( 'success' !== $feeds['status'] ) {
+				return null;
+			}
 
-		if ( is_array( $feeds['data'] ) ) {
+			$feed_object = null;
 
-			foreach ( $feeds['data'] as $feed_profile ) {
+			if ( is_array( $feeds['data'] ) ) {
 
-				if ( $feed_id === $feed_profile->id ) {
-					$feed_object = $feed_profile;
+				foreach ( $feeds['data'] as $feed_profile ) {
+
+					if ( $feed_id === $feed_profile->id ) {
+						$feed_object = $feed_profile;
+					}
+				}
+			} else {
+
+				if ( $feed_id === $feeds['data'] ) {
+					$feed_object = $feeds['data'];
 				}
 			}
-		} else {
 
-			if ( $feed_id === $feeds['data'] ) {
-				$feed_object = $feeds['data'];
-			}
+			return $feed_object;
+		} catch ( \Exception $e ) {
+
+			Logger::log( $e->getMessage(), 'error' );
+
+			throw $e;
 		}
-
-		return $feed_object;
 	}
 
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -482,16 +482,15 @@ class Base {
 				throw new \Exception( esc_html__( 'Wrong feed info.', 'pinterest-for-woocommerce' ) );
 			}
 
-			$feed_object = null;
-
 			foreach ( $feeds['data'] as $feed_profile ) {
 
 				if ( $feed_id === $feed_profile->id ) {
-					$feed_object = $feed_profile;
+					return $feed_profile;
 				}
 			}
 
-			return $feed_object;
+			// No feed found.
+			throw new \Exception( esc_html__( 'No feed found with the requested ID.', 'pinterest-for-woocommerce' ) );
 
 		} catch ( \Exception $e ) {
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -478,6 +478,10 @@ class Base {
 				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
 			}
 
+			if ( ! is_array( $feeds['data'] ) ) {
+				throw new \Exception( esc_html__( 'Wrong feed info.', 'pinterest-for-woocommerce' ) );
+			}
+
 			$feed_object = null;
 
 			foreach ( $feeds['data'] as $feed_profile ) {

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -460,6 +460,27 @@ class Base {
 
 
 	/**
+	 * Get a specific merchant's feed using the given arguments.
+	 *
+	 * @param string $merchant_id The merchant ID the feed belongs to.
+	 * @param string $feed_id     The ID of the feed.
+	 *
+	 * @return mixed
+	 */
+	public static function get_merchant_feed( $merchant_id, $feed_id ) {
+		return self::make_request(
+			"catalogs/{$merchant_id}/feed_profiles/",
+			'GET',
+			array(
+				'feed_profile' => $feed_id,
+			),
+			'',
+			MINUTE_IN_SECONDS
+		);
+	}
+
+
+	/**
 	 * Get a specific merchant's feed report using the given arguments.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -475,7 +475,7 @@ class Base {
 			$feeds = self::get_merchant_feeds( $merchant_id );
 
 			if ( 'success' !== $feeds['status'] ) {
-				return null;
+				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
 			}
 
 			$feed_object = null;

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -465,7 +465,7 @@ class Base {
 	 * @param string $merchant_id The merchant ID the feed belongs to.
 	 * @param string $feed_id     The ID of the feed.
 	 *
-	 * @return mixed|null
+	 * @return mixed
 	 *
 	 * @throws \Exception PHP Exception.
 	 */

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -460,20 +460,17 @@ class Base {
 
 
 	/**
-	 * Get a specific merchant's feed using the given arguments.
+	 * Get a specific merchant's feeds using the given arguments.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.
-	 * @param string $feed_id     The ID of the feed.
 	 *
 	 * @return mixed
 	 */
-	public static function get_merchant_feed( $merchant_id, $feed_id ) {
+	public static function get_merchant_feeds( $merchant_id ) {
 		return self::make_request(
 			"catalogs/{$merchant_id}/feed_profiles/",
 			'GET',
-			array(
-				'feed_profile' => $feed_id,
-			),
+			array(),
 			'',
 			MINUTE_IN_SECONDS
 		);

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -466,6 +466,8 @@ class Base {
 	 * @param string $feed_id     The ID of the feed.
 	 *
 	 * @return mixed|null
+	 *
+	 * @throws \Exception PHP Exception.
 	 */
 	public static function get_merchant_feed( $merchant_id, $feed_id ) {
 		try {
@@ -494,6 +496,7 @@ class Base {
 			}
 
 			return $feed_object;
+
 		} catch ( \Exception $e ) {
 
 			Logger::log( $e->getMessage(), 'error' );

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -480,18 +480,10 @@ class Base {
 
 			$feed_object = null;
 
-			if ( is_array( $feeds['data'] ) ) {
+			foreach ( $feeds['data'] as $feed_profile ) {
 
-				foreach ( $feeds['data'] as $feed_profile ) {
-
-					if ( $feed_id === $feed_profile->id ) {
-						$feed_object = $feed_profile;
-					}
-				}
-			} else {
-
-				if ( $feed_id === $feeds['data'] ) {
-					$feed_object = $feeds['data'];
+				if ( $feed_id === $feed_profile->id ) {
+					$feed_object = $feed_profile;
 				}
 			}
 

--- a/src/API/Base.php
+++ b/src/API/Base.php
@@ -460,14 +460,14 @@ class Base {
 
 
 	/**
-	 * Get a specific merchant's feed using the given arguments.
+	 * Get a specific merchant's feed report using the given arguments.
 	 *
 	 * @param string $merchant_id The merchant ID the feed belongs to.
 	 * @param string $feed_id     The ID of the feed.
 	 *
 	 * @return mixed
 	 */
-	public static function get_merchant_feed( $merchant_id, $feed_id ) {
+	public static function get_merchant_feed_report( $merchant_id, $feed_id ) {
 		return self::make_request(
 			"catalogs/datasource/feed_report/{$merchant_id}/",
 			'GET',

--- a/src/API/FeedIssues.php
+++ b/src/API/FeedIssues.php
@@ -279,7 +279,7 @@ class FeedIssues extends VendorAPI {
 	 */
 	private static function get_feed_workflow( $feed_id ) {
 		$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
-		$feed_report = $merchant_id ? Base::get_merchant_feed( $merchant_id, $feed_id ) : false;
+		$feed_report = $merchant_id ? Base::get_merchant_feed_report( $merchant_id, $feed_id ) : false;
 
 		if ( ! $feed_report || 'success' !== $feed_report['status'] ) {
 			throw new \Exception( esc_html__( 'Could not get feed report from Pinterest.', 'pinterest-for-woocommerce' ), 400 );

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -347,7 +347,7 @@ class FeedState extends VendorAPI {
 		try {
 
 			// Get feed ingestion status.
-			$feed_report = $merchant_id ? Base::get_merchant_feed( $merchant_id, $feed_id ) : false;
+			$feed_report = $merchant_id ? Base::get_merchant_feed_report( $merchant_id, $feed_id ) : false;
 
 			if ( ! $feed_report || 'success' !== $feed_report['status'] ) {
 				throw new \Exception( esc_html__( 'Response error when trying to get feed report from Pinterest.', 'pinterest-for-woocommerce' ) );

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -262,29 +262,13 @@ class FeedState extends VendorAPI {
 				throw new \Exception( esc_html__( 'Could not get merchant info.', 'pinterest-for-woocommerce' ) );
 			}
 
-			$feed = Base::get_merchant_feeds( $merchant_id );
+			$feed = Base::get_merchant_feed( $merchant_id, $feed_id );
 
-			if ( 'success' !== $feed['status'] ) {
+			if ( ! $feed ) {
 				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
 			}
 
-			if ( is_array( $feed['data'] ) ) {
-
-				foreach ( $feed['data'] as $feed_profile ) {
-
-					if ( $feed_id === $feed_profile->id ) {
-						$feed_object = $feed_profile;
-					}
-				}
-			} else {
-				$feed_object = $feed['data'];
-			}
-
-			if ( ! $feed_object ) {
-				throw new \Exception( esc_html__( 'Product feed not found in merchant.', 'pinterest-for-woocommerce' ) );
-			}
-
-			if ( 'ACTIVE' !== $feed_object->feed_status ) {
+			if ( 'ACTIVE' !== $feed->feed_status ) {
 				throw new \Exception( esc_html__( 'Product feed not active.', 'pinterest-for-woocommerce' ) );
 			}
 
@@ -295,13 +279,13 @@ class FeedState extends VendorAPI {
 					$status       = 'success';
 					$status_label = esc_html__( 'Product feed configured for ingestion on Pinterest', 'pinterest-for-woocommerce' );
 
-					if ( ! empty( $feed_object->location_config->full_feed_fetch_freq ) ) {
+					if ( ! empty( $feed->location_config->full_feed_fetch_freq ) ) {
 						$extra_info = wp_kses_post(
 							sprintf(
 								/* Translators: %1$s The URL of the product feed, %2$s Time string */
 								__( 'Pinterest will fetch your <a href="%1$s" target="_blank">product feed</a> every %2$s', 'pinterest-for-woocommerce' ),
-								$feed_object->location_config->full_feed_fetch_location,
-								human_time_diff( 0, ( $feed_object->location_config->full_feed_fetch_freq / 1000 ) )
+								$feed->location_config->full_feed_fetch_location,
+								human_time_diff( 0, ( $feed->location_config->full_feed_fetch_freq / 1000 ) )
 							)
 						);
 					}

--- a/src/API/FeedState.php
+++ b/src/API/FeedState.php
@@ -247,11 +247,12 @@ class FeedState extends VendorAPI {
 	private function add_feed_registration_state( $result ) {
 
 		$merchant_id = Pinterest_For_Woocommerce()::get_data( 'merchant_id' );
+		$feed_id     = Pinterest_For_Woocommerce()::get_data( 'feed_registered' );
 		$extra_info  = '';
 
 		try {
 
-			if ( empty( $merchant_id ) ) {
+			if ( empty( $merchant_id ) || empty( $feed_id ) ) {
 				throw new \Exception( esc_html__( 'Product feed not yet configured on Pinterest.', 'pinterest-for-woocommerce' ), 200 );
 			}
 
@@ -261,7 +262,29 @@ class FeedState extends VendorAPI {
 				throw new \Exception( esc_html__( 'Could not get merchant info.', 'pinterest-for-woocommerce' ) );
 			}
 
-			if ( 'ACTIVE' !== $merchant['data']->product_pin_feed_profile->feed_status ) {
+			$feed = Base::get_merchant_feeds( $merchant_id );
+
+			if ( 'success' !== $feed['status'] ) {
+				throw new \Exception( esc_html__( 'Could not get feed info.', 'pinterest-for-woocommerce' ) );
+			}
+
+			if ( is_array( $feed['data'] ) ) {
+
+				foreach ( $feed['data'] as $feed_profile ) {
+
+					if ( $feed_id === $feed_profile->id ) {
+						$feed_object = $feed_profile;
+					}
+				}
+			} else {
+				$feed_object = $feed['data'];
+			}
+
+			if ( ! $feed_object ) {
+				throw new \Exception( esc_html__( 'Product feed not found in merchant.', 'pinterest-for-woocommerce' ) );
+			}
+
+			if ( 'ACTIVE' !== $feed_object->feed_status ) {
 				throw new \Exception( esc_html__( 'Product feed not active.', 'pinterest-for-woocommerce' ) );
 			}
 
@@ -272,13 +295,13 @@ class FeedState extends VendorAPI {
 					$status       = 'success';
 					$status_label = esc_html__( 'Product feed configured for ingestion on Pinterest', 'pinterest-for-woocommerce' );
 
-					if ( ! empty( $merchant['data']->product_pin_feed_profile->location_config->full_feed_fetch_freq ) ) {
+					if ( ! empty( $feed_object->location_config->full_feed_fetch_freq ) ) {
 						$extra_info = wp_kses_post(
 							sprintf(
 								/* Translators: %1$s The URL of the product feed, %2$s Time string */
 								__( 'Pinterest will fetch your <a href="%1$s" target="_blank">product feed</a> every %2$s', 'pinterest-for-woocommerce' ),
-								$merchant['data']->product_pin_feed_profile->location_config->full_feed_fetch_location,
-								human_time_diff( 0, ( $merchant['data']->product_pin_feed_profile->location_config->full_feed_fetch_freq / 1000 ) )
+								$feed_object->location_config->full_feed_fetch_location,
+								human_time_diff( 0, ( $feed_object->location_config->full_feed_fetch_freq / 1000 ) )
 							)
 						);
 					}

--- a/src/ProductSync.php
+++ b/src/ProductSync.php
@@ -561,7 +561,7 @@ class ProductSync {
 			$prev_registered             = self::get_registered_feed_id();
 			if ( false !== $prev_registered ) {
 				try {
-					$feed                        = API\Base::get_merchant_feed( $merchant['data']->id, $prev_registered );
+					$feed                        = API\Base::get_merchant_feed_report( $merchant['data']->id, $prev_registered );
 					$product_pin_feed_profile_id = $feed['data']->feed_profile_id;
 				} catch ( \Throwable $e ) {
 					$product_pin_feed_profile_id = false;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Changes on this PR aims to solve [this issue](https://github.com/woocommerce/pinterest-for-woocommerce/issues/228)

#

- Get the correct feed when a merchant has multiple feed profiles.


### Screenshots:


### Detailed test instructions:

1. Create a feed profile from https://www.pinterest.com/product-catalogs/ directly and then disable it
2. Register feed profile from Woocommerce plugin to same user
3. Feed status will be correct now

### Changelog entry

>

